### PR TITLE
Fix get_token function and improve error messages

### DIFF
--- a/zebra/zebra/doctype/rfid_logs/rfid_logs.py
+++ b/zebra/zebra/doctype/rfid_logs/rfid_logs.py
@@ -8,6 +8,6 @@ class RFIDLogs(Document):
 	def after_insert(self):
 		""" When record is inserted check for the equipment with the rfid no. and update the location field """
 		equipment = frappe.get_doc('Equipment', {'rfid_number': self.id})
-		if equipment.last_location != self.location:
+		if not equipment.last_location or equipment.last_location != self.location:
 			equipment.last_location = self.location
 			equipment.save()

--- a/zebra/zebra/doctype/rfid_reader/rfid_reader.py
+++ b/zebra/zebra/doctype/rfid_reader/rfid_reader.py
@@ -24,10 +24,11 @@ def get_setting(doc):
 def get_token(doc):
     #doc = get_setting(doc)
     url = f'{doc.zebra_url}/cloud/localRestLogin'
-    headers = {"Content-Type": "text/plain", "Authorization": "Basic YWRtaW46U3RhcnQxMjMh"}
-    res = requests.get(url, \
-            auth=HTTPDigestAuth(f'{doc.username}', f'doc.get_password("password")'), \
-            headers=headers, verify=False)
+    res = requests.get(url, auth=(f'{doc.username}', f'{doc.get_password("password")}'), verify=False)
+    # headers = {"Content-Type": "text/plain", "Authorization": "Basic YWRtaW46U3RhcnQxMjMh"}
+    # res = requests.get(url, \
+    #         auth=HTTPDigestAuth(f'{doc.username}', f'doc.get_password("password")'), \
+    #         headers=headers, verify=False)
     return res
 
 @frappe.whitelist()
@@ -44,9 +45,9 @@ def start_tag_read(doc):
             time.sleep(5)
             frappe.msgprint("We are now started reading Zebra Tags...")
         else:
-            frappe.msgprint("Something went wrong please try again later!")
+            frappe.msgprint("Something went wrong please try again later! {}".format(response.text))
     else:
-        frappe.msgprint("Something went wrong please try again later!")
+        frappe.msgprint("Something went wrong please try again later! {}".format(response.text))
 
 @frappe.whitelist()
 def zebra_operations(operation, doc):
@@ -69,6 +70,6 @@ def zebra_operations(operation, doc):
             else:
                 return response.text #frappe.msgprint(f'{response.text}')
         else:
-            frappe.msgprint("Something went wrong please try again later!")
+            frappe.msgprint("Something went wrong please try again later! {}".format(response.text))
     else:
-        frappe.msgprint("Something went wrong please try again later!")
+        frappe.msgprint("Something went wrong please try again later! {}".format(response.text))


### PR DESCRIPTION
- The `get_token` function was not working properly, apparently because there were some authentication credential hard coded that is not valid anymore. This function was rewritten.
- The error message in RFID Reader was not descriptive so I added the message we get from the API:
![Captura de pantalla de 2023-06-28 15-54-20](https://github.com/phamos-eu/zebra/assets/6966715/2bc683cd-1a7b-4c19-9a6f-9cb5bbcfbb78)
